### PR TITLE
Added some tests and renamed

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-solmate/=lib/solmate/src/
 ds-test/=lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
+solmate/=lib/solmate/src/

--- a/src/SubdomainRegistrar.sol
+++ b/src/SubdomainRegistrar.sol
@@ -8,7 +8,7 @@ import {IBaseRegistrar} from "./ens/interfaces/IBaseRegistrar.sol";
 import {IResolver} from "./ens/interfaces/IResolver.sol";
 import {ERC721} from "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
 
-contract NounsRegistrar is AbstractSubdomainRegistrar {
+contract SubdomainRegistrar is AbstractSubdomainRegistrar {
 
     struct Domain {
         string name;
@@ -118,4 +118,5 @@ contract NounsRegistrar is AbstractSubdomainRegistrar {
 
         emit NewRegistration(label, subdomain, subdomainOwner);
     }
+
 }

--- a/src/test/Contract.t.sol
+++ b/src/test/Contract.t.sol
@@ -3,24 +3,32 @@ pragma solidity ^0.8.4;
 
 import {ENS} from "../ens/ENS.sol";
 import {ENSRegistry} from "../ens/ENSRegistry.sol";
+import {IResolver} from "../ens/interfaces/IResolver.sol";
 import {IBaseRegistrar} from "../ens/interfaces/IBaseRegistrar.sol";
 import {BaseRegistrarImplementation} from "../ens/BaseRegistrarImplementation.sol";
+import {SubdomainRegistrar} from "../SubdomainRegistrar.sol";
 import {BaseTest, console} from "./base/BaseTest.sol";
 import {Namehash} from "./utils/namehash.sol";
+import {TestResolver} from "./utils/TestResolver.sol";
+import {TestErc721Token} from "./utils/TestErc721Token.sol";
 import "forge-std/Vm.sol";
 
 contract ContractTest is BaseTest {
 
     address controller = address(0x1337c);
     address bob = address(0x133702);
+    address alice = address(0x133706969);
     bytes32 namehashEth = Namehash.namehash('eth');
 
     ENS ens;
     IBaseRegistrar registrar;
+    SubdomainRegistrar subdomainRegistrar;
+    IResolver resolver; 
 
     function setUp() public {
         vm.label(controller, "Controller");
         vm.label(bob, "Bob");
+        vm.label(alice, "Alice");
         vm.label(address(this), "TestContract");
 
         ens = new ENSRegistry();
@@ -34,6 +42,13 @@ contract ContractTest is BaseTest {
             address(registrar)
         );
         vm.warp(90 days + 1); // Warp ahead of the ENS grace period.
+        
+        // set up subdomain registrar contract 
+        resolver = new TestResolver();
+
+        // unclear why this token is actually necessary, leave it for now
+        TestErc721Token token = new TestErc721Token();
+        subdomainRegistrar = new SubdomainRegistrar(ens, token, resolver);
     }
 
     function testValidateSetUp() public {
@@ -43,15 +58,35 @@ contract ContractTest is BaseTest {
 
     function testRegisterNounsDomain() public {
         uint256 hashedNouns = uint256(keccak256(abi.encodePacked('nouns')));
+        registerTLD(hashedNouns);
+        assertEq(ens.owner(Namehash.namehash('nouns.eth')), bob);
+        assertEq(registrar.ownerOf(hashedNouns), bob);
+    }
+    
+    function testRegisterSubdomain() public {
+        uint256 tldLabel = uint256(keccak256(abi.encodePacked('nouns')));
+        registerTLD(tldLabel);
+
+        vm.startPrank(bob);
+        registrar.approve(address(subdomainRegistrar), tldLabel);
+        subdomainRegistrar.configureDomain('nouns');
+        vm.stopPrank();
+
+        vm.startPrank(alice);
+        subdomainRegistrar.register(keccak256(abi.encodePacked('nouns')), 'alice', alice);
+        vm.stopPrank();
+
+        assertEq(ens.owner(Namehash.namehash('alice.nouns.eth')), address(subdomainRegistrar));
+        assertEq(resolver.addr(Namehash.namehash('alice.nouns.eth')), alice);
+    }
+    
+    function registerTLD(uint256 hashedTLD) private {
         vm.startPrank(controller);
         registrar.register(
-            hashedNouns,
+            hashedTLD,
             bob,
             1 days
         );
         vm.stopPrank();
-
-        assertEq(ens.owner(Namehash.namehash('nouns.eth')), bob);
-        assertEq(registrar.ownerOf(hashedNouns), bob);
     }
 }


### PR DESCRIPTION
Renamed NounsRegistry -> SubdomainRegistry because this is not specific to nouns. Can register any ens domain w this contract.

Were just missing tests to actually mess around with subnodes via this contract. Def not exhaustive, but for my own understanding of the contracts.